### PR TITLE
Add ansible_python_interpreter to role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+python_interpreter: /usr/bin/python3
+
 elasticsearch_data_directory: /var/lib/elasticsearch
 elasticsearch_home_directory: /usr/share/elasticsearch
 elasticsearch_service_group: elasticsearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,8 @@
   register: temp_dir
 
 - name: Download Elasticsearch rpm {{ resource_bucket_elasticsearch_prefix }}/elasticsearch-{{ elasticsearch_version }}-x86_64.rpm
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   aws_s3:
     bucket: "{{ resource_bucket_name }}"
     object: "{{ resource_bucket_elasticsearch_prefix }}/elasticsearch-{{ elasticsearch_version }}-x86_64.rpm"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Download Elasticsearch rpm {{ resource_bucket_elasticsearch_prefix }}/elasticsearch-{{ elasticsearch_version }}-x86_64.rpm
   vars:
-    ansible_python_interpreter: /usr/bin/python3
+    ansible_python_interpreter: {{ python_version }}
   aws_s3:
     bucket: "{{ resource_bucket_name }}"
     object: "{{ resource_bucket_elasticsearch_prefix }}/elasticsearch-{{ elasticsearch_version }}-x86_64.rpm"


### PR DESCRIPTION
This has come about as we are migrating the logging-stack AMIs from a CentOS base image to Amazon Linux 2. We use the aws_s3 module to pull down the rpm in this role and it currently fails due to the module defaulting to use `/usr/bin/python` instead of python3.  

The change adds a vars block thats allows Ansible to interoperate the version of python we decide to use in which he have specified via a variable and defaulted to `/usr/bin/python3`. 

Partially resolves: DVOP-1826